### PR TITLE
Handle Delete Operations in Admission Webhook

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.1.0"
 kubeVersion: ">= 1.14"
 description: |

--- a/hub/templates/admission-controller.yaml
+++ b/hub/templates/admission-controller.yaml
@@ -23,22 +23,22 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
     rules:
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [ "extensions" ]
         apiVersions: [ "v1beta1" ]
         resources: [ "ingresses" ]
         scope: "Namespaced"
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [ "networking.k8s.io" ]
         apiVersions: [ "v1beta1" ]
         resources: [ "ingresses" ]
         scope: "Namespaced"
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [ "networking.k8s.io" ]
         apiVersions: [ "v1" ]
         resources: [ "ingresses" ]
         scope: "Namespaced"
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [ "traefik.containo.us" ]
         apiVersions: [ "v1alpha1" ]
         resources: [ "ingressroutes" ]


### PR DESCRIPTION
### Description

This PR adds the delete operation to the admission webhook as we need them to properly restore quotas.

Need by https://github.com/traefik/hub-agent/pull/57, but will break access control before it's merged.