### PR TITLE
fix: installation on k8s clusters with a pre-release version

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -1,8 +1,10 @@
 apiVersion: v2
 name: hub
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.1.0"
-kubeVersion: ">= 1.14"
+# Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
+# This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
+kubeVersion: ">= 1.14.0-0"
 description: |
   Traefik Hub is an all-in-one global networking platform that provides contextual observability,
   end-to-end connectivity, and zero-trust security for all of your mission-critical Kubernetes workloads.


### PR DESCRIPTION
## Goal

This PR fixes an issue when the chart is installed on a k8s cluster with a pre-release version. For example, on GKE the version is ` v1.19.9-gke.1900` which leads to a failed installation with the following message: `Error: chart requires kubeVersion: >= 1.14 which is incompatible with Kubernetes v1.19.9-gke.1900`.

As explained in https://github.com/helm/helm/issues/3810, to fix this issue the pre-release suffix `-0` has to be added to the `kubeVersion`.

Co-authored-by: Baptiste Mayelle <baptiste.mayelle@traefik.io>