### PR TITLE
Adds a subchart to template an AccessControlPolicy.

### DIFF
--- a/hub/charts/acp/.helmignore
+++ b/hub/charts/acp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/hub/charts/acp/Chart.yaml
+++ b/hub/charts/acp/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: acp
+description: Template for Traefik Hub AccessControlPolicy
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/hub/charts/acp/templates/AccessControlPolicy.yaml
+++ b/hub/charts/acp/templates/AccessControlPolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: AccessControlPolicy
+metadata:
+  name: {{ .Values.name }}
+spec:
+{{- if .Values.basicAuth.users }}
+  basicAuth: {{- toYaml .Values.basicAuth | nindent 4 }}
+{{- end }}
+{{- if .Values.digestAuth.users }}
+  digestAuth: {{- toYaml .Values.digestAuth | nindent 4 }}
+{{- end }}
+{{- if .Values.jwt.signingSecret }}
+  jwt: {{- toYaml .Values.jwt | nindent 4 }}
+{{- end }}

--- a/hub/charts/acp/templates/_helpers.tpl
+++ b/hub/charts/acp/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "acp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "acp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "acp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "acp.labels" -}}
+helm.sh/chart: {{ include "acp.chart" . }}
+{{ include "acp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "acp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "acp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "acp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "acp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/hub/charts/acp/values.yaml
+++ b/hub/charts/acp/values.yaml
@@ -1,0 +1,16 @@
+name: "my-acp"
+basicAuth:
+  # Create passwords with: htpasswd -nB [USERNAME]
+  #users: "user:$apr1$qs42pk1o$r1igImqwPOBxGOHdnRGRI1,user2:$apr1$hsge07nv$9J6KUZOoHnUxsK1ws3X/z1"
+  users: ""
+  stripAuthorizationHeader: true
+  forwardUsernameHeader: "User"
+jwt:
+  signingSecret: ""
+  stripAuthorizationHeader: true
+  forwardHeaders:
+    Name: name
+digestAuth:
+  # Create passwords with: htdigest -c digest.db [REALM] [USERNAME]
+  #users: "user:relam:$apr1$qs42pk1o$r1igImqwPOBxGOHdnRGRI1"
+  users: ""


### PR DESCRIPTION
This adds a subchart that is useful for templating AccessControlPolicy objects.

You can use it like this:

```
BASIC_AUTH_USERS=$(docker run --rm -it httpd htpasswd -nbB asdf asdf)
DIGEST_AUTH_USERS="...."
JWT_SIGNING_SECRET="....."

## Basic auth example:
helm template hub/hub/charts/acp --set name=my-basic-acp --set basicAuth.users=${BASIC_AUTH_USERS} | kubectl apply -f - 
## Digest auth example:
helm template hub/hub/charts/acp --set name=my-digest-acp --set digestAuth.users=${DIGEST_AUTH_USERS} | kubectl apply -f - 
## JWT auth example:
helm template hub/hub/charts/acp --set name=my-jwt-acp --set jwt.signingSecret=${JWT_SIGNING_SECRET} | kubectl apply -f - 
```

A more flexible bash function that can setup multiple basic auth users at once:

```
# Bash function that must be sourced or pasted:
create_basic_auth_users() {
    [ "${#@}" -eq 0 ] && echo "Enter usernames as arguments" && return
    BASIC_AUTH_USERS=()
    for USERNAME in "$@"
    do
        read -p "Enter the password for ${USERNAME}: " PASSWORD
        echo "Generating password hash ..."
        BASIC_AUTH_USERS+=($(kubectl run -n default --rm -i --tty tmp-htpasswd --image=httpd --restart=Never -- htpasswd -nbB ${USERNAME} ${PASSWORD} | head -1))
    done
    printf -v JOINED_USERS '%s,' "${BASIC_AUTH_USERS[@]}"
    JOINED_USERS=$(echo $JOINED_USERS | sed 's/,/\\,/g')
    helm template hub/hub/charts/acp --set basicAuth.users=${JOINED_USERS%\\,} | \
       tee | kubectl apply -f -
}
```

Then create users like this (will prompt for passwords for fred, bob, mary, and sally):

```
create_basic_auth_users fred bob mary sally
```