### PR TITLE
feat: add patch to the RBAC ingress policy of the controller

### DIFF
--- a/hub-agent/templates/rbac/cluster-role-controller.yaml
+++ b/hub-agent/templates/rbac/cluster-role-controller.yaml
@@ -85,6 +85,7 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
   - apiGroups:
       - apps


### PR DESCRIPTION
This PR adds the ability for the hub controller to patch an ingress. 