### PR TITLE
feat: remove ACP namespace and add custom domains

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 0.25.0
+version: 0.26.0
 appVersion: "v0.5.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/crds/edge-ingress.yaml
+++ b/hub-agent/crds/edge-ingress.yaml
@@ -27,12 +27,8 @@ spec:
       name: ACP
       priority: 1
       type: string
-    - jsonPath: .spec.acp.namespace
-      name: ACP Namespace
-      priority: 1
-      type: string
-    - jsonPath: .status.url
-      name: URL
+    - jsonPath: .status.urls
+      name: URLs
       type: string
     - jsonPath: .status.connection
       name: Connection
@@ -90,14 +86,19 @@ spec:
               domain:
                 description: Domain is the Domain for accessing the exposed service.
                 type: string
+              customDomains:
+                description: CustomDomains is the list of custom domains for accessing the exposed service.
+                type: array
+                items:
+                  type: string
               specHash:
                 description: SpecHash is a hash representing the the EdgeIngressSpec
                 type: string
               syncedAt:
                 format: date-time
                 type: string
-              url:
-                description: URL is the URL for accessing the exposed service.
+              urls:
+                description: URLs is the list of coma separated URL for accessing the exposed service.
                 type: string
               version:
                 type: string


### PR DESCRIPTION
This PR updates the EdgeIngress CRD:
- Add custom domains in its status
- Remove ACP namespace (resource is not namespaced)