### PR TITLE
🐛 templating error with additional args

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 1.1.1
+version: 1.1.2
 appVersion: "v1.0.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/templates/deployment-controller.yaml
+++ b/hub-agent/templates/deployment-controller.yaml
@@ -84,7 +84,7 @@ spec:
             {{ end -}}
             {{ end -}}
           {{- with .Values.controllerDeployment.args -}}
-          {{- range . -}}
+          {{ range . }}
             - {{ . | quote }}
           {{- end }}
           {{- end }}

--- a/hub-agent/tests/deployment-controller_test.yaml
+++ b/hub-agent/tests/deployment-controller_test.yaml
@@ -118,3 +118,17 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args[1]
           value: --token=$(HUB_SECRET_TOKEN)
+  - it: should set args for controller
+    set:
+      token: test
+      controllerDeployment:
+        args:
+        - --log-level=debug
+        - --platform-url=https://hub.traefik.io/agent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[7]
+          value: --log-level=debug
+      - equal:
+          path: spec.template.spec.containers[0].args[8]
+          value: --platform-url=https://hub.traefik.io/agent

--- a/hub-agent/tests/deployment-tunnel_test.yaml
+++ b/hub-agent/tests/deployment-tunnel_test.yaml
@@ -105,3 +105,17 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args[1]
           value: --token=$(HUB_SECRET_TOKEN)
+  - it: should set args for tunnel
+    set:
+      token: test
+      tunnelDeployment:
+        args:
+        - --log-level=debug
+        - --platform-url=https://hub.traefik.io/agent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[4]
+          value: --log-level=debug
+      - equal:
+          path: spec.template.spec.containers[0].args[5]
+          value: --platform-url=https://hub.traefik.io/agent


### PR DESCRIPTION
This PR is fixing an issue introduced in https://github.com/traefik/hub-helm-chart/pull/66, line endings were being removed in the `range` causing invalid YAML to be outputted when specifying additional args