### PR TITLE
Add custom domains to edgeIngress CRD

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 1.1.2
+version: 1.2.0
 appVersion: "v1.0.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/crds/edge-ingress.yaml
+++ b/hub-agent/crds/edge-ingress.yaml
@@ -16,97 +16,105 @@ spec:
     singular: edgeingress
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.service.name
-      name: Service
-      type: string
-    - jsonPath: .spec.service.port
-      name: Port
-      type: string
-    - jsonPath: .spec.acp.name
-      name: ACP
-      priority: 1
-      type: string
-    - jsonPath: .status.urls
-      name: URLs
-      type: string
-    - jsonPath: .status.connection
-      name: Connection
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: EdgeIngress defines an edge ingress.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - jsonPath: .spec.service.name
+          name: Service
+          type: string
+        - jsonPath: .spec.service.port
+          name: Port
+          type: string
+        - jsonPath: .spec.acp.name
+          name: ACP
+          priority: 1
+          type: string
+        - jsonPath: .status.urls
+          name: URLs
+          type: string
+        - jsonPath: .status.connection
+          name: Connection
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: EdgeIngress defines an edge ingress.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: The desired behavior of this edge ingress.
-            properties:
-              acp:
-                description: EdgeIngressACP configures the ACP to use on the Ingress.
-                properties:
-                  name:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: The desired behavior of this edge ingress.
+              properties:
+                acp:
+                  description: EdgeIngressACP configures the ACP to use on the Ingress.
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                customDomains:
+                  description: CustomDomains are the custom domains for accessing the
+                    exposed service.
+                  items:
                     type: string
-                required:
-                - name
-                type: object
-              service:
-                description: EdgeIngressService configures the service to exposed
-                  on the edge.
-                properties:
-                  name:
-                    type: string
-                  port:
-                    type: integer
-                required:
-                - name
-                - port
-                type: object
-            required:
-            - service
-            type: object
-          status:
-            description: The current status of this edge ingress.
-            properties:
-              connection:
-                description: Connection is the status of the underlying connection
-                  to the edge.
-                type: string
-              domain:
-                description: Domain is the Domain for accessing the exposed service.
-                type: string
-              customDomains:
-                description: CustomDomains is the list of custom domains for accessing the exposed service.
-                type: array
-                items:
+                  type: array
+                service:
+                  description: EdgeIngressService configures the service to exposed
+                    on the edge.
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                  required:
+                    - name
+                    - port
+                  type: object
+              required:
+                - service
+              type: object
+            status:
+              description: The current status of this edge ingress.
+              properties:
+                connection:
+                  description: Connection is the status of the underlying connection
+                    to the edge.
                   type: string
-              specHash:
-                description: SpecHash is a hash representing the the EdgeIngressSpec
-                type: string
-              syncedAt:
-                format: date-time
-                type: string
-              urls:
-                description: URLs is the list of coma separated URL for accessing the exposed service.
-                type: string
-              version:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                customDomains:
+                  description: CustomDomains are the custom domains for accessing the
+                    exposed service.
+                  items:
+                    type: string
+                  type: array
+                domain:
+                  description: Domain is the Domain for accessing the exposed service.
+                  type: string
+                specHash:
+                  description: SpecHash is a hash representing the EdgeIngressSpec
+                  type: string
+                syncedAt:
+                  format: date-time
+                  type: string
+                urls:
+                  description: URLs is the list of coma separated URL for accessing
+                    the exposed service.
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
### Description

This PR update ```edgeIngress``` CRD to support customDomains edition.

Related to [this](https://github.com/traefik/hub-agent-kubernetes/pull/28) and [this](https://github.com/traefik/hub-tunnel/pull/55) PR 