### PR TITLE
feat: Reasonable default domain for tunnelhost

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 1.5.7
+version: 1.6.0
 appVersion: "v1.4.2"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be defined.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/templates/_helpers.tpl
+++ b/hub-agent/templates/_helpers.tpl
@@ -57,3 +57,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ template "hub-helm-chart.chart" . }}
 {{- end }}
 {{- end }}
+
+{{/* Default Traefik Proxy service */}}
+{{- define "hub-helm-chart.traefikService" -}}
+traefik-hub.{{ .Values.traefikNamespace }}.svc.cluster.local
+{{- end }}

--- a/hub-agent/templates/deployment-auth-server.yaml
+++ b/hub-agent/templates/deployment-auth-server.yaml
@@ -52,10 +52,10 @@ spec:
             - auth-server
             - --listen-addr=:8080
             {{- with .Values.authServerDeployment.args }}
-            {{- range . }}
+             {{- range . }}
             - {{ . | quote }}
-              {{- end }}
-              {{- end }}
+             {{- end }}
+            {{- end }}
           env:
           readinessProbe:
             httpGet:

--- a/hub-agent/templates/deployment-controller.yaml
+++ b/hub-agent/templates/deployment-controller.yaml
@@ -63,6 +63,8 @@ spec:
             {{ if .Values.controllerDeployment.traefik.metricsURL -}}
             - --traefik.metrics-url={{ .Values.controllerDeployment.traefik.metricsURL }}
             {{ end -}}
+            {{ else -}}
+            - --traefik.metrics-url=http://{{ template "hub-helm-chart.traefikService" . }}:9100/metrics
             {{ end -}}
           {{- with .Values.controllerDeployment.args -}}
           {{ range . }}

--- a/hub-agent/templates/deployment-controller.yaml
+++ b/hub-agent/templates/deployment-controller.yaml
@@ -50,24 +50,24 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - controller
-            {{ if .Values.tokenSecretRef -}}
+            {{- if .Values.tokenSecretRef }}
             - --token=$(HUB_SECRET_TOKEN)
-            {{ else -}}
+            {{- else }}
             - --token={{ required "A valid .Values.token or .Values.tokenSecretRef is required." .Values.token }}
-            {{ end -}}
+            {{- end }}
             - --acp-server.listen-addr=:8443
             - --acp-server.cert=/var/run/hub-agent-kubernetes/cert.pem
             - --acp-server.key=/var/run/hub-agent-kubernetes/key.pem
             - --acp-server.auth-server-addr=http://hub-agent-auth-server.{{ .Release.Namespace }}.svc.cluster.local
-            {{ if .Values.controllerDeployment.traefik -}}
-            {{ if .Values.controllerDeployment.traefik.metricsURL -}}
+            {{- if .Values.controllerDeployment.traefik }}
+            {{- if .Values.controllerDeployment.traefik.metricsURL }}
             - --traefik.metrics-url={{ .Values.controllerDeployment.traefik.metricsURL }}
-            {{ end -}}
-            {{ else -}}
+            {{- end }}
+            {{- else }}
             - --traefik.metrics-url=http://{{ template "hub-helm-chart.traefikService" . }}:9100/metrics
-            {{ end -}}
-          {{- with .Values.controllerDeployment.args -}}
-          {{ range . }}
+            {{- end }}
+          {{- with .Values.controllerDeployment.args }}
+          {{- range . }}
             - {{ . | quote }}
           {{- end }}
           {{- end }}

--- a/hub-agent/templates/deployment-controller.yaml
+++ b/hub-agent/templates/deployment-controller.yaml
@@ -70,6 +70,10 @@ spec:
           {{- end }}
           {{- end }}
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- range .Values.controllerDeployment.env }}
             - name: {{ .name }}
               value: {{ .value }}

--- a/hub-agent/templates/deployment-dev-portal.yaml
+++ b/hub-agent/templates/deployment-dev-portal.yaml
@@ -76,16 +76,16 @@ spec:
                 - ALL
           args:
             - dev-portal
-            {{ if .Values.tokenSecretRef -}}
+            {{- if .Values.tokenSecretRef }}
             - --token=$(HUB_SECRET_TOKEN)
-            {{ else -}}
+            {{- else }}
             - --token={{ required "A valid .Values.token or .Values.tokenSecretRef is required." .Values.token }}
-            {{ end -}}
+            {{- end }}
             - --listen-addr=:8080
             {{- with .Values.devPortalDeployment.args }}
-            {{- range . }}
+             {{- range . }}
             - {{ . | quote }}
-            {{- end }}
+             {{- end }}
             {{- end }}
           env:
             {{- if .Values.tokenSecretRef }}

--- a/hub-agent/templates/deployment-tunnel.yaml
+++ b/hub-agent/templates/deployment-tunnel.yaml
@@ -54,8 +54,12 @@ spec:
             {{ else -}}
             - --token={{ required "A valid .Values.token or .Values.tokenSecretRef is required." .Values.token }}
             {{ end -}}
-            - --traefik.tunnel-host={{ required "A valid .Values.tunnelDeployment.traefik.tunnelHost is required." .Values.tunnelDeployment.traefik.tunnelHost }}
             - --traefik.tunnel-port={{ .Values.tunnelDeployment.traefik.tunnelPort }}
+            {{ if .Values.tunnelDeployment.traefik.tunnelHost -}}
+            - --traefik.tunnel-host={{ required "A valid .Values.tunnelDeployment.traefik.tunnelHost is required." .Values.tunnelDeployment.traefik.tunnelHost }}
+            {{ else -}}
+            - --traefik.tunnel-host={{ template "hub-helm-chart.traefikService" . }}
+            {{ end -}}
           {{- with .Values.tunnelDeployment.args -}}
           {{- range . }}
             - {{ . | quote }}

--- a/hub-agent/templates/deployment-tunnel.yaml
+++ b/hub-agent/templates/deployment-tunnel.yaml
@@ -49,22 +49,22 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - tunnel
-            {{ if .Values.tokenSecretRef -}}
+            {{- if .Values.tokenSecretRef }}
             - --token=$(HUB_SECRET_TOKEN)
-            {{ else -}}
+            {{- else }}
             - --token={{ required "A valid .Values.token or .Values.tokenSecretRef is required." .Values.token }}
-            {{ end -}}
+            {{- end }}
             - --traefik.tunnel-port={{ .Values.tunnelDeployment.traefik.tunnelPort }}
-            {{ if .Values.tunnelDeployment.traefik.tunnelHost -}}
+            {{- if .Values.tunnelDeployment.traefik.tunnelHost }}
             - --traefik.tunnel-host={{ .Values.tunnelDeployment.traefik.tunnelHost }}
-            {{ else -}}
+            {{- else }}
             - --traefik.tunnel-host={{ template "hub-helm-chart.traefikService" . }}
-            {{ end -}}
-          {{- with .Values.tunnelDeployment.args -}}
+            {{- end }}
+          {{- with .Values.tunnelDeployment.args }}
           {{- range . }}
             - {{ . | quote }}
-          {{ end }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/hub-agent/templates/deployment-tunnel.yaml
+++ b/hub-agent/templates/deployment-tunnel.yaml
@@ -56,7 +56,7 @@ spec:
             {{ end -}}
             - --traefik.tunnel-port={{ .Values.tunnelDeployment.traefik.tunnelPort }}
             {{ if .Values.tunnelDeployment.traefik.tunnelHost -}}
-            - --traefik.tunnel-host={{ required "A valid .Values.tunnelDeployment.traefik.tunnelHost is required." .Values.tunnelDeployment.traefik.tunnelHost }}
+            - --traefik.tunnel-host={{ .Values.tunnelDeployment.traefik.tunnelHost }}
             {{ else -}}
             - --traefik.tunnel-host={{ template "hub-helm-chart.traefikService" . }}
             {{ end -}}

--- a/hub-agent/templates/deployment-tunnel.yaml
+++ b/hub-agent/templates/deployment-tunnel.yaml
@@ -73,6 +73,10 @@ spec:
               drop:
                 - ALL
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- if .Values.tokenSecretRef }}
             - name: HUB_SECRET_TOKEN
               valueFrom:

--- a/hub-agent/tests/deployment-controller_test.yaml
+++ b/hub-agent/tests/deployment-controller_test.yaml
@@ -42,9 +42,9 @@ tests:
           - name: "TEST_ENV_VAR"
             value: "testvalue"
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: TEST_ENV_VAR
             value: testvalue
   - it: should set token env var when secretRef set
@@ -53,9 +53,9 @@ tests:
         name: hub-token
         key: token
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: HUB_SECRET_TOKEN
             valueFrom:
               secretKeyRef:

--- a/hub-agent/tests/deployment-controller_test.yaml
+++ b/hub-agent/tests/deployment-controller_test.yaml
@@ -67,16 +67,16 @@ tests:
         name: hub-token
         key: token
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args[1]
-          value: --token=$(HUB_SECRET_TOKEN)
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --token=$(HUB_SECRET_TOKEN)
   - it: should set token when set
     set:
       token: "test"
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args[1]
-          value: --token=test
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --token=test
   - it: should ignore token when secretRef set
     set:
       token: "test"
@@ -84,9 +84,9 @@ tests:
         name: hub-token
         key: token
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args[1]
-          value: --token=$(HUB_SECRET_TOKEN)
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --token=$(HUB_SECRET_TOKEN)
   - it: should set args for controller
     set:
       token: test
@@ -95,9 +95,37 @@ tests:
           - --log-level=debug
           - --platform-url=https://hub.traefik.io/agent
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args[7]
-          value: --log-level=debug
-      - equal:
-          path: spec.template.spec.containers[0].args[8]
-          value: --platform-url=https://hub.traefik.io/agent
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-level=debug
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --platform-url=https://hub.traefik.io/agent
+  - it: should have metrics url defaults
+    set:
+      token: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.metrics-url=http://traefik-hub.$(POD_NAMESPACE).svc.cluster.local:9100/metrics
+  - it: should set metrics url
+    set:
+      token: test
+      controllerDeployment:
+        traefik:
+          metricsURL: http://my-service/metrics
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.metrics-url=http://my-service/metrics
+
+  - it: should not set metrics url
+    set:
+      token: test
+      controllerDeployment:
+        traefik:
+          metricsURL: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.metrics-url

--- a/hub-agent/tests/deployment-tunnel_test.yaml
+++ b/hub-agent/tests/deployment-tunnel_test.yaml
@@ -40,9 +40,9 @@ tests:
         name: hub-token
         key: token
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: HUB_SECRET_TOKEN
             valueFrom:
               secretKeyRef:

--- a/hub-agent/tests/deployment-tunnel_test.yaml
+++ b/hub-agent/tests/deployment-tunnel_test.yaml
@@ -82,9 +82,34 @@ tests:
           - --log-level=debug
           - --platform-url=https://hub.traefik.io/agent
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args[4]
-          value: --log-level=debug
-      - equal:
-          path: spec.template.spec.containers[0].args[5]
-          value: --platform-url=https://hub.traefik.io/agent
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-level=debug
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --platform-url=https://hub.traefik.io/agent
+          value: --token=$(HUB_SECRET_TOKEN)
+  - it: should have tunnel config defaults
+    set:
+      token: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.tunnel-host=traefik-hub.$(POD_NAMESPACE).svc.cluster.local
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.tunnel-port=9901
+  - it: should set tunnel config
+    set:
+      token: test
+      tunnelDeployment:
+        traefik:
+          tunnelPort: 1234
+          tunnelHost: traefik-service
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.tunnel-host=traefik-service
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --traefik.tunnel-port=1234

--- a/hub-agent/values.yaml
+++ b/hub-agent/values.yaml
@@ -14,6 +14,9 @@ token: ""
 #    name: hub-token
 #    key: token
 
+# The Namespace of your Traefik Proxy installation
+traefikNamespace: $(POD_NAMESPACE)
+
 controllerDeployment:
   # Additional deployment annotations
   annotations:
@@ -24,9 +27,9 @@ controllerDeployment:
   podAnnotations: {}
   # Additional pods labels
   podLabels: {}
-  # Traefik metrics configuration
-  traefik:
-    metricsURL: http://traefik-hub.$(POD_NAMESPACE).svc.cluster.local:9100/metrics
+  # Traefik Proxy configuration
+  traefik: {}
+#    metricsURL: http://traefik-hub.$(POD_NAMESPACE).svc.cluster.local:9100/metrics
 
   args:
     - --log-level=debug
@@ -61,10 +64,10 @@ tunnelDeployment:
   podAnnotations: {}
   # Additional pods labels
   podLabels: {}
-  # Traefik tunnel configuration
+  # Traefik Proxy tunnel configuration
   traefik:
-    tunnelHost: traefik-hub.$(POD_NAMESPACE).svc.cluster.local
     tunnelPort: 9901
+#    tunnelHost: traefik-hub.$(POD_NAMESPACE).svc.cluster.local
   args:
     - --log-level=debug
 

--- a/hub-agent/values.yaml
+++ b/hub-agent/values.yaml
@@ -29,7 +29,7 @@ controllerDeployment:
   podLabels: {}
   # Traefik Proxy configuration
   traefik: {}
-#    metricsURL: http://traefik-hub.$(POD_NAMESPACE).svc.cluster.local:9100/metrics
+    # metricsURL: http://traefik-hub.$(POD_NAMESPACE).svc.cluster.local:9100/metrics
 
   args:
     - --log-level=debug
@@ -67,7 +67,7 @@ tunnelDeployment:
   # Traefik Proxy tunnel configuration
   traefik:
     tunnelPort: 9901
-#    tunnelHost: traefik-hub.$(POD_NAMESPACE).svc.cluster.local
+    # tunnelHost: traefik-hub.$(POD_NAMESPACE).svc.cluster.local
   args:
     - --log-level=debug
 

--- a/hub-agent/values.yaml
+++ b/hub-agent/values.yaml
@@ -26,7 +26,7 @@ controllerDeployment:
   podLabels: {}
   # Traefik metrics configuration
   traefik:
-    metricsURL: http://traefik-hub:9100/metrics
+    metricsURL: http://traefik-hub.$(POD_NAMESPACE).svc.cluster.local:9100/metrics
 
   args:
     - --log-level=debug
@@ -63,7 +63,7 @@ tunnelDeployment:
   podLabels: {}
   # Traefik tunnel configuration
   traefik:
-    tunnelHost: traefik-hub
+    tunnelHost: traefik-hub.$(POD_NAMESPACE).svc.cluster.local
     tunnelPort: 9901
   args:
     - --log-level=debug

--- a/hub-agent/values.yaml
+++ b/hub-agent/values.yaml
@@ -26,7 +26,8 @@ controllerDeployment:
   podLabels: {}
   # Traefik metrics configuration
   traefik:
-    metricsURL: http://traefik-hub.hub-agent.svc.cluster.local:9100/metrics
+    metricsURL: http://traefik-hub:9100/metrics
+
   args:
     - --log-level=debug
   # env:
@@ -62,7 +63,7 @@ tunnelDeployment:
   podLabels: {}
   # Traefik tunnel configuration
   traefik:
-    tunnelHost: traefik-hub.hub-agent.svc.cluster.local
+    tunnelHost: traefik-hub
     tunnelPort: 9901
   args:
     - --log-level=debug


### PR DESCRIPTION
### What does this PR do?

People installing the helm chart into another namespace then we usually document may experience hidden issues.
The current default values are very opiniated and assume the helm chart will be installed in "hub-agent".

In a default kubernetes cluster the dns resolution is usually able to leverage the search domain to reach services in the same namespace without knowing the fqdn.

### Motivation

Ease the installation into another namespace without setting any values (or installing along an existing traefik proxy). I had to troubleshoot a bit to understand why a published service timeout, this might help other people to get started quickly.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--
HOW TO WRITE A GOOD PULL REQUEST? 
https://doc.traefik.io/traefik/contributing/submitting-pull-requests/
-->
