### PR TITLE
feat: add token on dev-portal deployment

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 1.5.4-alpha.1
+version: 1.5.5-alpha.1
 appVersion: "v1.3.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 1.5.4
+version: 1.5.4-alpha.1
 appVersion: "v1.3.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/templates/deployment-dev-portal.yaml
+++ b/hub-agent/templates/deployment-dev-portal.yaml
@@ -76,11 +76,25 @@ spec:
                 - ALL
           args:
             - dev-portal
+            {{ if .Values.tokenSecretRef -}}
+            - --token=$(HUB_SECRET_TOKEN)
+            {{ else -}}
+            - --token={{ required "A valid .Values.token or .Values.tokenSecretRef is required." .Values.token }}
+            {{ end -}}
             - --listen-addr=:8080
             {{- with .Values.devPortalDeployment.args }}
             {{- range . }}
             - {{ . | quote }}
             {{- end }}
+            {{- end }}
+          env:
+            {{- if .Values.tokenSecretRef }}
+            - name: HUB_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- with .Values.tokenSecretRef }}
+                  {{- toYaml . | nindent 18 }}
+                  {{- end -}}
             {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/hub-agent/tests/deployment-dev-portal_test.yaml
+++ b/hub-agent/tests/deployment-dev-portal_test.yaml
@@ -4,6 +4,7 @@ templates:
 tests:
   - it: should have 1 replicas
     set:
+      token: "test"
       devPortalDeployment:
         replicas: 1
     asserts:
@@ -35,13 +36,57 @@ tests:
       - equal:
           path: spec.template.metadata.labels.custom-label
           value: plop
+  - it: should set token env var when secretRef set
+    set:
+      tokenSecretRef:
+        name: hub-token
+        key: token
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: HUB_SECRET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hub-token
+                key: token
+  - it: should set args when secretRef set
+    set:
+      tokenSecretRef:
+        name: hub-token
+        key: token
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --token=$(HUB_SECRET_TOKEN)
+  - it: should set token when set
+    set:
+      token: "test"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --token=test
+  - it: should ignore token when secretRef set
+    set:
+      token: "test"
+      tokenSecretRef:
+        name: hub-token
+        key: token
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --token=$(HUB_SECRET_TOKEN)
   - it: should set args for dev-portal
     set:
       token: test
       devPortalDeployment:
         args:
           - --log-level=debug
+          - --platform-url=https://hub.traefik.io/agent
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].args[2]
+          path: spec.template.spec.containers[0].args[3]
           value: --log-level=debug
+      - equal:
+          path: spec.template.spec.containers[0].args[4]
+          value: --platform-url=https://hub.traefik.io/agent


### PR DESCRIPTION
### What does this PR do?

This PR adds the value in `tokenSecretRef` or `token` to the dev-portal deployment.

### Motivation

This component now needs to talk directly to the platform. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

Related to https://github.com/traefik/hub-agent-kubernetes/pull/107

<!--
HOW TO WRITE A GOOD PULL REQUEST? 
https://doc.traefik.io/traefik/contributing/submitting-pull-requests/
-->
