### PR TITLE
docs: document chart pre-release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@
 
 - [ ] Yes, I updated the tests accordingly
 - [ ] Yes, I ran `make test` and all the tests passed
+- [ ] Yes, I bumped the alpha version of the Chart.
 
 <!--
 HOW TO WRITE A GOOD PULL REQUEST? 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
           generateReleaseNotes: true
+          prerelease: ${{ contains(steps.chart_version.outputs.CHART_VERSION, '') }}
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Publish Helm chart

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ helm uninstall hub-agent --namespace hub-namespace
 
 ## Contributing 
 
+### Versioning
+
+We use [Semantic Versioning](https://semver.org/).
+
+Pull requests must bump the `version` of the chart specified in [Chart.yaml](./Chart.yaml):
+- The new version must be an alpha pre-release (e.g. 1.6.0-alpha.1)
+- The new version must reflect the nature of the change, according to Semver specification.
+
+A chart can be made available publicly by removing the pre-release suffix, this must be done on a separate PR by a maintainer.
+
+Every version bump are published on the Helm Chart Registry.
+
+The latest pre-release version of the Chart can be used by specifying `--devel` on the `install` and `upgrade` commands.
+
 ### Launch unit tests
 
 ```bash


### PR DESCRIPTION
### What does this PR do?

This PR documents the new versioning process.

### Motivation

Charts are published as soon as the version changes but it sometimes contains changes that are not available yet on the latest agent version. To keep publishing new versions on every change we can leverage semver pre-release.  

### More

- [ ] ~Yes, I updated the tests accordingly~
- [ ] ~Yes, I ran `make test` and all the tests passed~

<!--
HOW TO WRITE A GOOD PULL REQUEST? 
https://doc.traefik.io/traefik/contributing/submitting-pull-requests/
-->
