### PR TITLE
Remove key requirement in APIKey ACP

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hub-agent
-version: 1.5.5-alpha.1
+version: 1.5.5-alpha.2
 appVersion: "v1.3.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/hub-agent/crds/access-control-policy.yaml
+++ b/hub-agent/crds/access-control-policy.yaml
@@ -87,7 +87,6 @@ spec:
                           - id
                           - value
                         type: object
-                      minItems: 1
                       type: array
                   required:
                     - keySource


### PR DESCRIPTION
### Motivation

This pull request removes the API keys validation which enforces that an API Key ACP should have at least one key. This allows having an ACP which denies all requests.

Co-authored-by: Antoine Couchard <antoine.couchard@traefik.io>

