### PR TITLE
chore: release hub-agent-kubernetes

### DIFF
--- a/hub-agent/Chart.yaml
+++ b/hub-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hub-agent
-version: 1.5.5
-appVersion: "v1.4.0"
+version: 1.5.6
+appVersion: "v1.4.1"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be defined.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.14.0-0"


### PR DESCRIPTION
### What does this PR do?

This pull request bumps the hub-agent-kubernetes version to `v1.4.1`.

Note: this needs to be merged when the hub-agent-kubernetes build is finished.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed
- [ ] Yes, I bumped the alpha version of the Chart.

<!--
HOW TO WRITE A GOOD PULL REQUEST? 
https://doc.traefik.io/traefik/contributing/submitting-pull-requests/
-->
